### PR TITLE
Update status of 335/336/337/346/347

### DIFF
--- a/_data/numerics.yaml
+++ b/_data/numerics.yaml
@@ -1674,13 +1674,16 @@ values:
         numeric: "335"
         origin: Hybrid
         conflict: true
-        comment: Since hybrid 8.2.0
+        obsolete: true
+        comment: From hybrid 8.2.0 to 8.2.36, moved to 339
 
     -
         name: RPL_WHOISACCOUNTONLY
         numeric: "335"
         origin: Nefarious
         conflict: true
+        obsolete: true
+        comment: Replaced by RPL_WHOISSPECIAL
 
     -
         name: RPL_INVITELIST
@@ -1688,9 +1691,10 @@ values:
         origin: Hybrid
         format: "<client> :<channel>"
         comment: >
-            Since hybrid 8.2.0. Not to be confused with the more widely used 346.
+            A "list of channels a client is invited to" sent with /INVITE.
 
-            A "list of channels a client is invited to" sent with /INVITE
+            Since hybrid 8.2.0. Not to be confused with the more widely used 346
+            (RPL_INVEXLIST) which lists masks.
 
         conflict: true
 
@@ -1699,6 +1703,9 @@ values:
         numeric: "336"
         origin: Nefarious
         conflict: true
+        obsolete: true
+        comment: >
+            Nefarious and others moved to 335.
 
     -
         name: RPL_ENDOFINVITELIST
@@ -1707,7 +1714,8 @@ values:
         format: "<client> :End of /INVITE list."
         conflict: true
         comment: >
-            Since hybrid 8.2.0. Not to be confused with the more widely used 347.
+            Since hybrid 8.2.0. Not to be confused with the more widely used 347
+            (RPL_ENDOFINVEXLIST) which lists masks.
 
     -
         name: RPL_WHOISTEXT
@@ -1824,7 +1832,8 @@ values:
         format: "<client> <channel> <invitemask>"
         comment: >
             An invite mask for the invite mask list.
-            Also known as RPL_INVEXLIST in hybrid 8.2.0
+            Also known as RPL_INVEXLIST in hybrid 8.2.0.
+            Not to be confused with 336 (also called RPL_INVITELIST) which lists invited nicks.
 
     -
         name: RPL_ENDOFINVITELIST
@@ -1833,7 +1842,8 @@ values:
         format: "<client> <channel> :<info>"
         comment: >
             Termination of an RPL_INVITELIST list.
-            Also known as RPL_ENDOFINVEXLIST in hybrid 8.2.0
+            Also known as RPL_ENDOFINVEXLIST in hybrid 8.2.0.
+            Not to be confused with 336 (also called RPL_ENDOFINVITELIST) which lists invited nicks.
 
     -
         name: RPL_EXCEPTLIST


### PR DESCRIPTION
aka. the widely conflicting RPL_WHOISBOT, RPL_WHOISTEXT, RPL_INVITELIST, RPL_INVEXLIST, RPL_ENDOFINVITEDLIST, RPL_ENDOFINVEXLIST numerics.

References:

* https://github.com/ircd-hybrid/ircd-hybrid/commit/5ba9ed0363f34dc264fcbc2d568293d0dc9364bc
* https://github.com/inspircd/inspircd/commit/df17d47b6a17ee6214f7f501e3b9d73cb8acd36e
* https://github.com/unrealircd/unrealircd/commit/a11e6df64b9ab8fe27ecbc1300893bf8796dcebc
* https://github.com/evilnet/nefarious2/commit/9e7d55b9668ae730e3c31302fabc4df90437c0da